### PR TITLE
feat: added a quickswitch navigation pane

### DIFF
--- a/includes/css/dailyark.css
+++ b/includes/css/dailyark.css
@@ -489,3 +489,46 @@ footer a img {
 
 }
 
+.fg-dark {
+    color: #c3c3c3;
+}
+
+.full-width, .full-width > button {
+    width: 100%;
+    display: block;
+}
+
+.btn-group-vertical a {
+    text-decoration: none;
+}
+
+#quickswitch {
+    position: fixed;
+    left: 5px;
+    top: 65px;
+    z-index: -1;
+}
+
+#quickswitch .btn-secondary {
+    border-right: none;
+    border-left: none;
+    border-color: #050206;
+}
+
+#quickswitch .btn-secondary:first-child {
+    border-top: none;
+}
+
+#quickswitch .btn-secondary:last-child {
+    border-bottom: none;
+}
+
+.hidden {
+    display: none;
+}
+
+@media screen and (max-width: 1312px) {
+    #quickswitch {
+        display: none !important;
+    }
+}

--- a/includes/js/dailyark.js
+++ b/includes/js/dailyark.js
@@ -296,6 +296,26 @@ var weeklies = {
     },
 };
 
+const populateQuickswitch = function (timeFrame, char) {
+    if (timeFrame !== "dailychar")
+        return;
+
+    const button = document.createElement("button");
+    button.classList.add("btn");
+    button.classList.add("btn-secondary");
+    button.classList.add("bg-dark");
+    button.classList.add("fg-dark");
+    button.innerHTML = char;
+
+    const a = document.createElement("a");
+    a.classList.add("full-width");
+    a.href = "#" + char + "_dailychar";
+    a.appendChild(button);
+
+    const quickswitch = document.getElementById("quickswitch");
+    quickswitch.appendChild(a);
+};
+
 /**
  * Populate the HTML with data for a timeFrame and attach listeners
  * @param {String} timeFrame
@@ -1093,6 +1113,7 @@ window.onload = function () {
         for (const index in characterArray) {
             character = characterArray[index];
             for (const timeFrame of timeframesCharacter) {
+                populateQuickswitch(timeFrame, character);
                 populateTable(timeFrame, character);
                 draggableTable(timeFrame, character);
                 checkReset(timeFrame, character);
@@ -1114,6 +1135,12 @@ window.onload = function () {
 
     dropdownMenuHelper();
     tableEventListeners();
+
+    // Display quickswitch all at once. This stops the browser from looking
+    // as if it's partially loading the quickswitch pane as the site is loaded,
+    // because characters are added to quickswitch in the form of buttons
+    // from local storage.
+    document.getElementById("quickswitch").classList.remove("hidden");
 
     setInterval(function () {
         for (const timeFrame of timeframesRoster) {

--- a/index.html
+++ b/index.html
@@ -138,6 +138,9 @@
     </div>
 </nav>
 
+<div id="quickswitch" class="btn-group-vertical bg-dark hidden">
+</div>
+
 <div class="container-xl activity_tables" id="characters_body">
     <div id="dailies" class="table_container dailies_table interact draggable" data-x="0" data-y="0">
         <table id="dailies_table" class="activity_table table table-dark table-striped table-hover" data-timeframe="dailies">


### PR DESCRIPTION
This can be used to switch quickly between your alts to their daily
sections. It removes an extra click from the process.

I tried media query hiding the sidepane to go along with the response navbar. I got it pretty good, however, there's a breakpoint bigger than this where the internal container resizes and I can't detect that inside of a media query. I could do this in JS, not sure it's worth it -- i just set its z-index to -1, so in that case, at least it doesn't intrude. In the majority of cases, however, it works as intended and has no quirks.